### PR TITLE
rename docker workdir, update websockets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM python:3.7
 # Create a group and user
 RUN addgroup uwsgi && useradd -g uwsgi uwsgi
 
-WORKDIR /opt/funcx-ws
+WORKDIR /opt/funcx-websocket-service
 
 COPY ./requirements.txt .
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 aioredis==1.3.1
 aiohttp==3.7.4.post0
-websockets==8.1
+websockets==9.1
 aio-pika==6.8.0
 git+https://github.com/funcx-faas/funcX.git@main#egg=funcx&subdirectory=funcx_sdk


### PR DESCRIPTION
Forgot to switch the name of the docker workdir.

I realized websockets also needs updating.