### PR TITLE
unpin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aioredis==1.3.1
-aiohttp==3.7.4.post0
-websockets==9.1
-aio-pika==6.8.0
+aioredis
+aiohttp
+websockets
+aio-pika


### PR DESCRIPTION
Fixes: https://github.com/funcx-faas/funcx-websocket-service/issues/17

Unpinning dependency versions in main branch