### PR TITLE
Idle connection close timer

### DIFF
--- a/funcx_websocket_service/connection.py
+++ b/funcx_websocket_service/connection.py
@@ -20,7 +20,8 @@ class WebSocketConnection:
             # if no messages are sent to this connection in a 10 minute
             # time span, close the connection
             if now - self.last_send_time > 10 * 60:
-                self.ws.close()
+                logger.debug('Closing WebSocket connection for being idle too long')
+                await self.ws.close()
                 return
 
             await asyncio.sleep(60)

--- a/funcx_websocket_service/connection.py
+++ b/funcx_websocket_service/connection.py
@@ -1,0 +1,26 @@
+import asyncio
+import logging
+import time
+
+logger = logging.getLogger(__name__)
+
+
+class WebSocketConnection:
+    def __init__(self, ws):
+        self.ws = ws
+        self.last_send_time = time.time()
+
+    async def send(self, msg):
+        self.last_send_time = time.time()
+        await self.ws.send(msg)
+
+    async def check_idle(self):
+        while True:
+            now = time.time()
+            # if no messages are sent to this connection in a 10 minute
+            # time span, close the connection
+            if now - self.last_send_time > 10 * 60:
+                self.ws.close()
+                return
+
+            await asyncio.sleep(60)

--- a/funcx_websocket_service/connection.py
+++ b/funcx_websocket_service/connection.py
@@ -6,15 +6,39 @@ logger = logging.getLogger(__name__)
 
 
 class WebSocketConnection:
+    """A WebSocket connection that has important WebSocket session properties
+    for a single connected client, along with holding the client's WebSocket
+    object which is created by the server
+    """
+
     def __init__(self, ws):
+        """Initialize the WebSocket connection
+
+        Parameters
+        ----------
+        ws : WebSocket
+            WebSocket connection object created by websockets library
+        """
         self.ws = ws
         self.last_send_time = time.time()
 
-    async def send(self, msg):
+    async def send(self, msg: str):
+        """Send a message to this WebSocket connection. We want to call this
+        method for any sending because we want to keep track of when the last
+        message was sent to each connected client
+
+        Parameters
+        ----------
+        msg : str
+            Message to send
+        """
         self.last_send_time = time.time()
         await self.ws.send(msg)
 
     async def check_idle(self):
+        """Awaitable to check on a regular interval whether or not this
+        WebSocket connection has become idle, closing it if it has
+        """
         while True:
             now = time.time()
             # if no messages are sent to this connection in a 10 minute

--- a/funcx_websocket_service/connection.py
+++ b/funcx_websocket_service/connection.py
@@ -11,15 +11,21 @@ class WebSocketConnection:
     object which is created by the server
     """
 
-    def __init__(self, ws):
+    def __init__(self, ws, idle_close_time: int = 10 * 60):
         """Initialize the WebSocket connection
 
         Parameters
         ----------
         ws : WebSocket
             WebSocket connection object created by websockets library
+
+        idle_close_time : int
+            Time in seconds to wait for this connection to be idle before
+            it is closed. Idle for n seconds mean that no outgoing message has
+            been sent to the WebSocket for n seconds
         """
         self.ws = ws
+        self.idle_close_time = idle_close_time
         self.last_send_time = time.time()
 
     async def send(self, msg: str):
@@ -43,7 +49,7 @@ class WebSocketConnection:
             now = time.time()
             # if no messages are sent to this connection in a 10 minute
             # time span, close the connection
-            if now - self.last_send_time > 10 * 60:
+            if now - self.last_send_time > self.idle_close_time:
                 logger.debug('Closing WebSocket connection for being idle too long')
                 await self.ws.close()
                 return

--- a/funcx_websocket_service/server.py
+++ b/funcx_websocket_service/server.py
@@ -202,13 +202,13 @@ class WebSocketServer:
 
         return res
 
-    async def handle_mq_message(self, ws_conn, task_group_id: str, message):
+    async def handle_mq_message(self, ws_conn: WebSocketConnection, task_group_id: str, message):
         """Handles new messages coming off of the RabbitMQ queue
 
         Parameters
         ----------
-        ws : WebSocket connection
-            Connection to send messages to
+        ws_conn : WebSocketConnection
+            WebSocket connection
 
         task_group_id : str
             Task group ID for the queue
@@ -244,14 +244,14 @@ class WebSocketServer:
         else:
             logger.info('dispatched_to_user', extra=extra_logging)
 
-    async def mq_receive_task(self, ws_conn, task_group_id: str):
+    async def mq_receive_task(self, ws_conn: WebSocketConnection, task_group_id: str):
         """asyncio awaitable which handles expected exceptions from the
         RabbitMQ message handler
 
         Parameters
         ----------
-        ws : WebSocket connection
-            Connection to send messages to
+        ws_conn : WebSocketConnection
+            WebSocket connection
 
         task_group_id : str
             Task group ID to wait for RabbitMQ messages on
@@ -265,15 +265,15 @@ class WebSocketServer:
         except Exception as e:
             logger.exception(e)
 
-    async def mq_receive(self, ws_conn, task_group_id: str):
+    async def mq_receive(self, ws_conn: WebSocketConnection, task_group_id: str):
         """
         Receives completed tasks based on task_group_id on a RabbitMQ queue and sends them back
         to the user, after first confirming they own the task group they have requested
 
         Parameters
         ----------
-        ws : WebSocket connection
-            Connection to send messages to
+        ws : WebSocketConnection
+            WebSocket connection
 
         task_group_id : str
             Task group ID to wait for RabbitMQ messages on
@@ -309,13 +309,13 @@ class WebSocketServer:
                     async with message.process(requeue=True):
                         await self.handle_mq_message(ws_conn, task_group_id, message)
 
-    def ws_message_consumer(self, ws_conn, msg: str):
+    def ws_message_consumer(self, ws_conn: WebSocketConnection, msg: str):
         """Consumer for incoming WebSocket messages
 
         Parameters
         ----------
-        ws : WebSocket connection
-            Connection that message is coming from
+        ws : WebSocketConnection
+            WebSocket connection
 
         msg : str
             Incoming message

--- a/funcx_websocket_service/server.py
+++ b/funcx_websocket_service/server.py
@@ -272,7 +272,7 @@ class WebSocketServer:
 
         Parameters
         ----------
-        ws : WebSocketConnection
+        ws_conn : WebSocketConnection
             WebSocket connection
 
         task_group_id : str
@@ -314,7 +314,7 @@ class WebSocketServer:
 
         Parameters
         ----------
-        ws : WebSocketConnection
+        ws_conn : WebSocketConnection
             WebSocket connection
 
         msg : str


### PR DESCRIPTION
Fixes https://github.com/funcx-faas/funcx-websocket-service/issues/19

This adds an object that contains the WebSocket for connections along with additional client info, such as how long a connected client has been idle.

Currently, a task is created that checks every 60s whether or not a message has been sent to the connection in the past 10 min. If not, it closes the connection. We can change these times if needed.