### PR TITLE
Log all exceptions as json

### DIFF
--- a/funcx_websocket_service/application.py
+++ b/funcx_websocket_service/application.py
@@ -4,45 +4,51 @@ import logging
 from funcx_websocket_service.server import WebSocketServer
 from funcx_websocket_service.utils.loggers import set_stream_logger
 
+logger = logging.getLogger(__name__)
+
 
 def cli():
     """CLI entrypoint for WebSocket server that takes CLI args, gathers env vars,
     and starts the WebSocket server
     """
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-d", "--debug", action='store_true',
-                        help="Debug logging")
+    try:
+        parser = argparse.ArgumentParser()
+        parser.add_argument("-d", "--debug", action='store_true',
+                            help="Debug logging")
 
-    args = parser.parse_args()
+        args = parser.parse_args()
 
-    env_debug = os.environ.get('FUNCX_WEBSOCKET_SERVICE_DEBUG')
+        env_debug = os.environ.get('FUNCX_WEBSOCKET_SERVICE_DEBUG')
 
-    debug = args.debug is True or env_debug is not None
-    logger = set_stream_logger(level=logging.DEBUG if debug else logging.INFO)
+        debug = args.debug is True or env_debug is not None
+        global logger
+        logger = set_stream_logger(level=logging.DEBUG if debug else logging.INFO)
 
-    REDIS_HOST = os.environ.get('REDIS_HOST')
-    if not REDIS_HOST:
-        REDIS_HOST = os.environ.get('FUNCX_REDIS_MASTER_SERVICE_HOST')
-    REDIS_PORT = os.environ.get('REDIS_PORT')
-    RABBITMQ_HOST = os.environ.get('RABBITMQ_HOST')
-    if not RABBITMQ_HOST:
-        RABBITMQ_HOST = os.environ.get('FUNCX_RABBITMQ_SERVICE_HOST')
+        REDIS_HOST = os.environ.get('REDIS_HOST')
+        if not REDIS_HOST:
+            REDIS_HOST = os.environ.get('FUNCX_REDIS_MASTER_SERVICE_HOST')
+        REDIS_PORT = os.environ.get('REDIS_PORT')
+        RABBITMQ_HOST = os.environ.get('RABBITMQ_HOST')
+        if not RABBITMQ_HOST:
+            RABBITMQ_HOST = os.environ.get('FUNCX_RABBITMQ_SERVICE_HOST')
 
-    WEB_SERVICE_URI = os.environ.get('WEB_SERVICE_URI')
+        WEB_SERVICE_URI = os.environ.get('WEB_SERVICE_URI')
 
-    if REDIS_HOST is None:
-        REDIS_HOST = '127.0.0.1'
+        if REDIS_HOST is None:
+            REDIS_HOST = '127.0.0.1'
 
-    if REDIS_PORT is None:
-        REDIS_PORT = 6379
+        if REDIS_PORT is None:
+            REDIS_PORT = 6379
 
-    if RABBITMQ_HOST is None:
-        RABBITMQ_HOST = '127.0.0.1'
+        if RABBITMQ_HOST is None:
+            RABBITMQ_HOST = '127.0.0.1'
 
-    if WEB_SERVICE_URI is None:
-        WEB_SERVICE_URI = 'http://127.0.0.1:5000'
+        if WEB_SERVICE_URI is None:
+            WEB_SERVICE_URI = 'http://127.0.0.1:5000'
 
-    logger.info('Starting WebSocket Server')
-    logger.debug(f'Using redis host: {REDIS_HOST}, redis port: {REDIS_PORT}, RabbitMQ host: {RABBITMQ_HOST}, web service URI: {WEB_SERVICE_URI}')
+        logger.info('Starting WebSocket Server')
+        logger.debug(f'Using redis host: {REDIS_HOST}, redis port: {REDIS_PORT}, RabbitMQ host: {RABBITMQ_HOST}, web service URI: {WEB_SERVICE_URI}')
 
-    WebSocketServer(REDIS_HOST, REDIS_PORT, RABBITMQ_HOST, WEB_SERVICE_URI)
+        WebSocketServer(REDIS_HOST, REDIS_PORT, RABBITMQ_HOST, WEB_SERVICE_URI)
+    except Exception:
+        logger.exception('An exception occurred while starting the server')

--- a/funcx_websocket_service/application.py
+++ b/funcx_websocket_service/application.py
@@ -1,4 +1,5 @@
 import os
+import sys
 import argparse
 import logging
 from funcx_websocket_service.server import WebSocketServer
@@ -51,4 +52,5 @@ def cli():
 
         WebSocketServer(REDIS_HOST, REDIS_PORT, RABBITMQ_HOST, WEB_SERVICE_URI)
     except Exception:
-        logger.exception('An exception occurred while starting the server')
+        logger.exception('Caught exception while starting server')
+        sys.exit(-1)

--- a/funcx_websocket_service/application.py
+++ b/funcx_websocket_service/application.py
@@ -53,4 +53,7 @@ def cli():
         WebSocketServer(REDIS_HOST, REDIS_PORT, RABBITMQ_HOST, WEB_SERVICE_URI)
     except Exception:
         logger.exception('Caught exception while starting server')
+        # log env variables, as the vars that are passed in are likely the reason
+        # for server start failing
+        logger.critical(os.environ)
         sys.exit(-1)

--- a/funcx_websocket_service/utils/loggers.py
+++ b/funcx_websocket_service/utils/loggers.py
@@ -21,4 +21,12 @@ def set_stream_logger(name='funcx_websocket_service', level=logging.DEBUG):
     formatter = jsonlogger.JsonFormatter('%(asctime)s %(name)s %(levelname)s %(message)s')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
+
+    # it is difficult to propogate exceptions from the WebSocket server
+    # handlers, so we simply need to add our JSON handler to the
+    # websockets.server logger
+    ws_logger = logging.getLogger("websockets.server")
+    ws_logger.setLevel(logging.ERROR)
+    ws_logger.addHandler(handler)
+
     return logger


### PR DESCRIPTION
Fixes https://github.com/funcx-faas/funcx-websocket-service/issues/22

Firstly, I realized exceptions here bubbling up all the way to the top are not being logged as JSON, so I wrapped a `try` block around the main entrypoint to the server

Additionally, exceptions are not being logged in JSON format for the WebSocket server connection handler. The websockets docs explain this can be handled by simply adding a handler to their `websockets.server` logger (https://websockets.readthedocs.io/en/stable/api/server.html#starting-a-server)