### PR TITLE
CI Job to Deploy main branch to dev cluster

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,7 +61,7 @@ jobs:
   deploy:
     needs: publish
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/ci_job'
+    if: github.ref == 'refs/heads/main'
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,3 +55,31 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
         tag: "${GITHUB_REF##*/}"
+
+#  If this is a merge to main branch then we want to restart the web service
+#  pod on dev cluster to pick up the changes
+  deploy:
+    needs: publish
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/ci_job'
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: scale to webservice pods to zero
+        uses: kodermax/kubectl-aws-eks@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_STAGING }}
+        with:
+          args:  scale deployment funcx-funcx-websocket-service --replicas=0
+
+      - name: scale to webservice pods back up
+        uses: kodermax/kubectl-aws-eks@master
+        env:
+          KUBE_CONFIG_DATA: ${{ secrets.KUBE_CONFIG_DATA_STAGING }}
+        with:
+          args:  scale deployment funcx-funcx-websocket-service --replicas=1


### PR DESCRIPTION
# Problem
We want merges to the main branch to be automatically deployed to dev cluster.

Partial solution to [ClubHouse issue 8785](https://app.clubhouse.io/globus/story/8785/add-cd-pipeline-webservice-for-dev-environment)

# Approach
Added a new job to the GitHub actions pipeline that runs after the docker image has been pushed, and only on the `main` branch.

It uses the captive Kubernetes account to scale the deployment to zero pods and then back up to one. This has the effect for restarting the one pod.

See [this action result](https://github.com/funcx-faas/funcx-websocket-service/actions/runs/1034479188) for what happens when it runs