### PR TITLE
change task transition to log type field

### DIFF
--- a/funcx_websocket_service/server.py
+++ b/funcx_websocket_service/server.py
@@ -225,7 +225,7 @@ class WebSocketServer:
             extra_logging = {
                 "task_id": task_id,
                 "task_group_id": task_group_id,
-                "task_transition": True
+                "type": "task_transition"
             }
             extra_logging.update(task_data)
 

--- a/funcx_websocket_service/server.py
+++ b/funcx_websocket_service/server.py
@@ -225,7 +225,7 @@ class WebSocketServer:
             extra_logging = {
                 "task_id": task_id,
                 "task_group_id": task_group_id,
-                "type": "task_transition"
+                "log_type": "task_transition"
             }
             extra_logging.update(task_data)
 


### PR DESCRIPTION
We should instead have a general "type" field in the json logs to specify what type of message is being logged when it is a special type