### PR TITLE
Add script to tag and release web socket service

### DIFF
--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -14,6 +14,13 @@ fi
 
 VERSION=$1
 
+SEMVER_REGEX="^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(\\-[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?(\\+[0-9A-Za-z-]+(\\.[0-9A-Za-z-]+)*)?$"
+
+if [[ ! $VERSION =~ $SEMVER_REGEX ]]; then
+  echo "Version should be a nice Semantic Version String (https://semver.org)"
+  exit 1
+fi
+
 verify_version() {
   FUNCX_VERSION=$(python3 -c "import funcx_websocket_service.version; print(funcx_websocket_service.version.VERSION)")
 
@@ -24,19 +31,18 @@ verify_version() {
       echo "Updating version.py to match release"
       sed "s/^VERSION *= *'.*'/VERSION = '$VERSION'/" funcx_websocket_service/version.py > funcx_websocket_service/version.py.bak
       mv  funcx_websocket_service/version.py.bak funcx_websocket_service/version.py
-      git status
   fi
 }
 
 
 create_release_branch () {
     echo "Creating branch"
-    git checkout -b "$VERSION"
+    git checkout -b "v$VERSION"
     git add funcx_websocket_service/version.py
     git commit -m "Update to version $VERSION"
 
     echo "Pushing branch"
-    git push origin "$VERSION"
+    git push origin "v$VERSION"
 }
 
 

--- a/tag_and_release.sh
+++ b/tag_and_release.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Script to release a new version of the web service
+# It does this by creating a branch named after the version, updating
+# version.py, committing those changes to the branch
+#
+# Usage:
+# tag_and_release.sh version
+# The version should be the semantic version for this new release
+
+if [ $# -ne 1 ]; then
+    echo "Usage tag_and_release version"
+    exit 1
+fi
+
+VERSION=$1
+
+verify_version() {
+  FUNCX_VERSION=$(python3 -c "import funcx_websocket_service.version; print(funcx_websocket_service.version.VERSION)")
+
+  if [[ $FUNCX_VERSION == "$VERSION" ]]
+  then
+      echo "Version requested matches package version: $VERSION"
+  else
+      echo "Updating version.py to match release"
+      sed "s/^VERSION *= *'.*'/VERSION = '$VERSION'/" funcx_websocket_service/version.py > funcx_websocket_service/version.py.bak
+      mv  funcx_websocket_service/version.py.bak funcx_websocket_service/version.py
+      git status
+  fi
+}
+
+
+create_release_branch () {
+    echo "Creating branch"
+    git checkout -b "$VERSION"
+    git add funcx_websocket_service/version.py
+    git commit -m "Update to version $VERSION"
+
+    echo "Pushing branch"
+    git push origin "$VERSION"
+}
+
+
+verify_version
+create_release_branch
+


### PR DESCRIPTION
# Problem
Deployment is cumbersome and error-prone

#Approach
Added a new `tag_and_release` script that:
1. Updates the version.py string to match the version
2. Creates a branch named after the version
3. Commits and pushes to trigger CI job
