### PR TITLE
Setup minimal mypy config

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
     - name: Check for vulnerabilities in libraries
       run: tox -e safety
     - name: Lint
-      run: tox -e lint
+      run: tox -e lint,mypy
     - name: Test
       run: tox -e py
   publish:

--- a/Makefile
+++ b/Makefile
@@ -2,4 +2,4 @@
 test:
 	tox
 lint:
-	tox -e lint
+	tox -e lint,mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,6 @@ exclude = .git,.tox,__pycache__,dist,venv,.venv*
 # not fail on up to 88 chars of width
 max-line-length = 88
 ignore = W503,W504,E203
+
+[mypy]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -13,8 +13,9 @@ commands = pre-commit run --all-files
 [testenv:mypy]  # TODO: start using this
 deps =
     mypy
+    types-requests
     types-redis
-commands = mypy funcx_web_service/
+commands = mypy funcx_websocket_service/
 
 [testenv:safety]
 deps = safety


### PR DESCRIPTION
Add `mypy` to `make lint` and CI runs, tweak configs, and fix flagged issues.

Of the mypy failures, two are interesting and nontrivial:
- `websockets.serve` is not well-typed for `mypy`, comment on the import with the fix links to relevant issue
- `mq_connection` gets the result of an unannotated `aio_pika` call, and mypy cannot deduce its type (now annotated as Any)

The `Any` annotation is just a quick hack to avoid diving into why this isn't properly typed right now.