### PR TITLE
Add a daily 'safety check' run

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   test:
+    timeout-minutes: 30
     strategy:
       matrix:
         python-version: [3.7]
@@ -32,6 +33,7 @@ jobs:
     - name: Test
       run: tox -e py
   publish:
+    timeout-minutes: 30
     needs: test
     runs-on: ubuntu-latest
     steps:
@@ -53,6 +55,7 @@ jobs:
 #  If this is a merge to main branch then we want to restart the web service
 #  pod on dev cluster to pick up the changes
   deploy:
+    timeout-minutes: 30
     needs: publish
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -1,0 +1,21 @@
+name: daily
+on:
+  # build every day at 4:00 AM UTC
+  schedule:
+    - cron: '0 4 * * *'
+  workflow_dispatch:
+
+jobs:
+  safety-check:
+    timeout-minutes: 20
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: main
+    - uses: actions/setup-python@v2
+    - name: install requirements
+      run: python -m pip install tox
+    - name: run safety check
+      run: tox -e safety
+

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,9 +9,14 @@ repos:
     - id: check-merge-conflict
     - id: trailing-whitespace
 - repo: https://github.com/sirosen/check-jsonschema
-  rev: 0.7.1
+  rev: 0.9.1
   hooks:
     - id: check-github-workflows
+    - id: check-jsonschema
+      name: "Check GitHub Workflows set timeout-minutes"
+      files: ^\.github/workflows/
+      types: [yaml]
+      args: ["--builtin-schema", "github-workflows-require-timeout"]
 - repo: https://gitlab.com/pycqa/flake8
   rev: 3.9.2
   hooks:


### PR DESCRIPTION
No notifications are sent by the job as of yet, but it provides the basis for sending notifications.

Also, update pre-commit linting on github workflows (latest version + check that workflow jobs always set timeouts).